### PR TITLE
Django 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,14 @@ env:
   - TOX_ENV=py-django-19
   - TOX_ENV=py-django-110
   - TOX_ENV=py-django-111
+  - TOX_ENV=py-django-20
 
 matrix:
   fast_finish: true
+
+  exclude:
+    - python: "2.7"
+      env: TOX_ENV=py-django-20
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -r requirements_test.txt

--- a/django_smoke_tests/generator.py
+++ b/django_smoke_tests/generator.py
@@ -18,6 +18,13 @@ from unittest import skip
 from .tests import SmokeTests
 
 
+def get_pattern(url_pattern):
+    if hasattr(url_pattern, 'regex'):  # dj < 2.0
+        return url_pattern.regex.pattern
+    else:                              # dj >= 2.0
+        return str(url_pattern.pattern)
+
+
 class HTTPMethodNotSupported(Exception):
     pass
 
@@ -89,7 +96,6 @@ class SmokeTestsGenerator:
 
     def execute(self):
         self.load_all_endpoints(URLResolver(r'^/', settings.ROOT_URLCONF).url_patterns)
-
         for url_pattern, lookup_str, url_name in self.all_patterns:
             if not self.app_names or self.is_url_inside_specified_app(lookup_str):
                 self.create_tests_for_endpoint(url_pattern, url_name)
@@ -112,11 +118,11 @@ class SmokeTestsGenerator:
         for url_pattern in url_list:
             if hasattr(url_pattern, 'url_patterns'):
                 self.load_all_endpoints(
-                    url_pattern.url_patterns, parent_url + url_pattern.regex.pattern
+                    url_pattern.url_patterns, parent_url + get_pattern(url_pattern)
                 )
             else:
                 self.all_patterns.append((
-                    parent_url + url_pattern.regex.pattern,
+                    parent_url + get_pattern(url_pattern),
                     self.get_lookup_str(url_pattern),
                     url_pattern.name
                 ))

--- a/django_smoke_tests/generator.py
+++ b/django_smoke_tests/generator.py
@@ -5,10 +5,14 @@ from django.conf import settings
 from django.utils.regex_helper import normalize
 
 try:
-    from django.urls import RegexURLResolver
+    from django.urls import URLResolver
 except ImportError:
-    # Django < 1.10
-    from django.core.urlresolvers import RegexURLResolver
+    # Django < 2.0
+    try:
+        from django.urls import RegexURLResolver as URLResolver
+    except ImportError:
+        # Django < 1.10
+        from django.core.urlresolvers import RegexURLResolver as URLResolver
 from unittest import skip
 
 from .tests import SmokeTests
@@ -84,7 +88,7 @@ class SmokeTestsGenerator:
         return test
 
     def execute(self):
-        self.load_all_endpoints(RegexURLResolver(r'^/', settings.ROOT_URLCONF).url_patterns)
+        self.load_all_endpoints(URLResolver(r'^/', settings.ROOT_URLCONF).url_patterns)
 
         for url_pattern, lookup_str, url_name in self.all_patterns:
             if not self.app_names or self.is_url_inside_specified_app(lookup_str):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -10,6 +10,19 @@ from .views import (
     ViewWithDRFAuth
 )
 
+try:
+    django2_url_patterns = []
+    from django.urls import path
+except ImportError:
+    # Django < 2.0
+    pass
+else:
+    django2_url_patterns = [
+        path(
+            'test-with-new-style-parameter/<int:parameter>', simple_method_view,
+            name='endpoint_with_new_style_parameter'
+        ),
+    ]
 
 # kept separately, because they are used in tests
 url_patterns_with_authentication = [
@@ -25,7 +38,6 @@ skipped_url_patterns = [
     url(r'^skipped-endpoint/$', skipped_view, name='skipped_endpoint'),
 ]
 
-
 urlpatterns = [
     url(r'^$', RedirectView.as_view(url='/', permanent=True), name='root_url'),
     url(r'^test/$', RedirectView.as_view(url='/', permanent=True), name='basic_endpoint'),
@@ -38,7 +50,7 @@ urlpatterns = [
     # fixed edge cases
     url(r'^app_urls/', include('tests.app.urls')),
 
-] + url_patterns_with_authentication + skipped_url_patterns
+] + url_patterns_with_authentication + skipped_url_patterns + django2_url_patterns
 
 router = DefaultRouter()
 router.register(r'view-set', SimpleViewSet, base_name='view-set')

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
 envlist =
-    {py27,py35}-django-18
-    {py27,py35}-django-19
-    {py27,py35}-django-110
+    {py27,py36}-django-18
+    {py27,py36}-django-19
+    {py27,py36}-django-110
+    {py27,py36}-django-111
+    {py36}-django-20
 
 [testenv]
 setenv =
@@ -13,9 +15,11 @@ deps =
     django-19: Django>=1.9,<1.10
     django-110: Django>=1.10,<1.11
     django-111: Django>=1.11,<2.0
+    django-20: Django>=2.0
     -r{toxinidir}/requirements_test.txt
 basepython =
     py: python
+    py36: python3.6
     py35: python3.5
     py34: python3.4
     py33: python3.3


### PR DESCRIPTION
Tox tests were successful.
Please check following:

- tox.ini: I have changed tox environment from py 3.5 to 3.6, I have added environment for dj 1.11, dj 2.0.

- There is problem with earlier url_patterns.regex.pattern, used on more places in generator, test_command and test_generator. I think it could be replaced with str(url_patterns.pattern) in dj 2.0+. Temporary I have used common function get_pattern() which I suggest to use as long as single writing is not possible. But maybe you have better solution.

Best regards,
Mirek
