### PR TITLE
Fix dj21

### DIFF
--- a/django_smoke_tests/management/commands/smoke_tests.py
+++ b/django_smoke_tests/management/commands/smoke_tests.py
@@ -14,10 +14,16 @@ class Command(BaseCommand):
         """
         Override in order to skip default parameters like verbosity, version, etc.
         """
-        parser = CommandParser(
-            self, prog="%s %s" % (os.path.basename(prog_name), subcommand),
-            description=self.help or None,
-        )
+        def _create_parser(*args):
+            return CommandParser(
+                *args,
+                prog="%s %s" % (os.path.basename(prog_name), subcommand),
+                description=self.help or None,
+            )
+        try:               # django 2.1+
+            parser = _create_parser()
+        except TypeError:  # django 2.0-
+            parser = _create_parser(self)
         # create hidden options (required by BaseCommand)
         parser.add_argument('--no-color', help=argparse.SUPPRESS)
         parser.add_argument('--pythonpath', help=argparse.SUPPRESS)

--- a/django_smoke_tests/management/commands/smoke_tests.py
+++ b/django_smoke_tests/management/commands/smoke_tests.py
@@ -18,8 +18,7 @@ class Command(BaseCommand):
             return CommandParser(
                 *args,
                 prog="%s %s" % (os.path.basename(prog_name), subcommand),
-                description=self.help or None,
-            )
+                description=self.help or None)
         try:               # django 2.1+
             parser = _create_parser()
         except TypeError:  # django 2.0-


### PR DESCRIPTION
Otherwise will fail with Django 2.1 (which is published today 2018-08-01).

CommandParser in Django 2.1 is now without arg "cmd".

I have tested with tox.ini incl. py37 and dj21.
I made separate PR for changed tox.ini so you can accept/change/reject that.
